### PR TITLE
Use regex browser check to prevent false positives

### DIFF
--- a/poftutor/build.gradle
+++ b/poftutor/build.gradle
@@ -51,6 +51,5 @@ dependencies {
     testCompile group: 'org.apiguardian', name: 'apiguardian-api', version: '1.0.0'
     compile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.0.1'
 
-    testRuntime group: 'org.seleniumhq.selenium', name: 'selenium-server', version: '3.6.0'
     testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.0.1'
 }

--- a/poftutor/src/main/java/tech/alexontest/poftutor/infrastructure/DriverType.java
+++ b/poftutor/src/main/java/tech/alexontest/poftutor/infrastructure/DriverType.java
@@ -1,8 +1,10 @@
 package tech.alexontest.poftutor.infrastructure;
 
+import java.util.regex.Pattern;
+
 public enum DriverType {
-    CHROME("Chrome"),
-    CHROME_LOCAL("Chrome"),
+    CHROME("^(?!.*?\\bOPR/\\b)^(?!.*?\\bEdge/\\b).*?\\bChrome/\\b.*?\\bSafari/\\b.*$"),
+    CHROME_LOCAL("^(?!.*?\\bOPR/\\b)^(?!.*?\\bEdge/\\b).*?\\bChrome/\\b.*?\\bSafari/\\b.*$"),
     CHROME_LOCAL_HEADLESS("HeadlessChrome"),
     EDGE("Edge"),
     FIREFOX("Firefox"),
@@ -10,13 +12,13 @@ public enum DriverType {
     OPERA("OPR/"),
     OPERA_LOCAL("OPR/"),;
 
-    private final String checkString;
+    private final Pattern regex;
 
-    DriverType(final String checkString) {
-        this.checkString = checkString;
+    DriverType(final String regexString) {
+        this.regex = Pattern.compile(regexString);
     }
 
-    public String getCheckString() {
-        return checkString;
+    public Pattern getRegex() {
+        return regex;
     }
 }

--- a/poftutor/src/main/java/tech/alexontest/poftutor/infrastructure/OperaDriverManager.java
+++ b/poftutor/src/main/java/tech/alexontest/poftutor/infrastructure/OperaDriverManager.java
@@ -50,8 +50,7 @@ public final class OperaDriverManager extends AbstractDriverManager implements W
     @Override
     public String createDriver() {
         final OperaOptions options = new OperaOptions()
-                .setBinary(new File("C:/Program Files/Opera/50.0.2762.58/opera.exe"));
-        //options.setCapability("browserName", "operablink");
+                .setBinary(new File("C:/Program Files/Opera/50.0.2762.67/opera.exe"));
         // add additional options here as required
         if (!isLocal) {
             setDriver(new RemoteWebDriver(getGridUrl(), options));

--- a/poftutor/src/test/java/tech/alexontest/poftutor/DriverFactoryTests.java
+++ b/poftutor/src/test/java/tech/alexontest/poftutor/DriverFactoryTests.java
@@ -12,6 +12,7 @@ import tech.alexontest.poftutor.infrastructure.AbstractCrossBrowserTest;
 import tech.alexontest.poftutor.infrastructure.DriverManagerFactory;
 import tech.alexontest.poftutor.infrastructure.DriverType;
 
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,10 +38,11 @@ class DriverFactoryTests extends AbstractCrossBrowserTest {
         final String homePageURL = "https://www.example.com/";
         final WebDriver driver = getDriver(homePageURL);
         final String agentString = (String) ((JavascriptExecutor) driver).executeScript("return navigator.userAgent;");
-        final String checkString = driverType.getCheckString();
+        final Pattern regex = driverType.getRegex();
         assertThat(agentString)
-                .as("Incorrect Browser Launched: Browser Agent String does not contain the check String.")
-                .contains(checkString);
+                .as("AgentString does not match pattern for %s", driverType.name())
+                .containsPattern(driverType.getRegex());
+
         assertThat(driver.getCurrentUrl())
                 .as(String.format(
                         "Check that browser '%1$s' successfully loads the homepage '%2$s'", browserName, homePageURL

--- a/poftutor/src/test/resources/tech/alexontest/poftutor/operaTests.csv
+++ b/poftutor/src/test/resources/tech/alexontest/poftutor/operaTests.csv
@@ -1,2 +1,2 @@
-OPERA_LOCAL, operaBlink, Opera Browser Tests can be run  on screen locally
-OPERA, operaBlink, Opera Browser Tests can be run on the grid
+OPERA_LOCAL, operablink, Opera Browser Tests can be run  on screen locally
+OPERA, operablink, Opera Browser Tests can be run on the grid


### PR DESCRIPTION
22/01/18 edited 27/01/18
Previously would not fail in most cases when requesting Chrome.